### PR TITLE
Fix 403 response

### DIFF
--- a/vkmax/client.py
+++ b/vkmax/client.py
@@ -44,7 +44,10 @@ class MaxClient:
             raise Exception("Already connected")
 
         _logger.info(f'Connecting to {WS_HOST}...')
-        self._connection = await websockets.connect(WS_HOST)
+        self._connection = await websockets.connect(
+            WS_HOST,
+            origin=websockets.Origin('https://web.max.ru'),
+        )
 
         self._recv_task = asyncio.create_task(self._recv_loop())
         _logger.info('Connected. Receive task started.')

--- a/vkmax/client.py
+++ b/vkmax/client.py
@@ -12,7 +12,7 @@ from functools import wraps
 
 WS_HOST = "wss://ws-api.oneme.ru/websocket"
 RPC_VERSION = 11
-APP_VERSION = "25.6.8"
+APP_VERSION = "25.9.15"
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
 
 _logger = logging.getLogger(__name__)

--- a/vkmax/client.py
+++ b/vkmax/client.py
@@ -13,6 +13,7 @@ from functools import wraps
 WS_HOST = "wss://ws-api.oneme.ru/websocket"
 RPC_VERSION = 11
 APP_VERSION = "25.6.8"
+USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
 
 _logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class MaxClient:
         self._connection = await websockets.connect(
             WS_HOST,
             origin=websockets.Origin('https://web.max.ru'),
+            user_agent_header=USER_AGENT
         )
 
         self._recv_task = asyncio.create_task(self._recv_loop())
@@ -152,7 +154,7 @@ class MaxClient:
                     "locale": "ru_RU",
                     "osVersion": "macOS",
                     "deviceName": "vkmax Python",
-                    "headerUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+                    "headerUserAgent": USER_AGENT,
                     "deviceLocale": "ru-RU",
                     "appVersion": APP_VERSION,
                     "screen": "956x1470 2.0x",


### PR DESCRIPTION
MAX returns 403 Forbidden on `MaxClient.connect` call. After some tests, I figured out that now their API requires `Origin` header to be set to `https://web.max.ru` (the current version of vkmax doesn't send this header at all).